### PR TITLE
Make Handling of Missing or Incorrect Api Key Consistent with Fever Api

### DIFF
--- a/app/fever_api/response.rb
+++ b/app/fever_api/response.rb
@@ -15,6 +15,9 @@ require_relative "write_mark_feed"
 require_relative "write_mark_group"
 
 module FeverAPI
+
+  API_VERSION = 3
+
   class Response
     ACTIONS = [
       Authentication,
@@ -39,7 +42,7 @@ module FeverAPI
     end
 
     def to_json
-      base_response = { api_version: 3 }
+      base_response = { api_version: API_VERSION }
       ACTIONS
         .inject(base_response) { |a, e| a.merge!(e.new.call(@params)) }
         .to_json

--- a/app/fever_api/response.rb
+++ b/app/fever_api/response.rb
@@ -15,7 +15,6 @@ require_relative "write_mark_feed"
 require_relative "write_mark_group"
 
 module FeverAPI
-
   API_VERSION = 3
 
   class Response

--- a/fever_api.rb
+++ b/fever_api.rb
@@ -13,7 +13,9 @@ module FeverAPI
     end
 
     before do
-      halt 200, {'Content-Type' => 'application/json'}, { api_version: FeverAPI::API_VERSION, auth: 0 }.to_json unless authenticated?(params[:api_key])
+      headers = { "Content-Type" => "application/json" }
+      body = { api_version: FeverAPI::API_VERSION, auth: 0 }.to_json
+      halt 200, headers, body unless authenticated?(params[:api_key])
     end
 
     def authenticated?(api_key)

--- a/fever_api.rb
+++ b/fever_api.rb
@@ -13,7 +13,7 @@ module FeverAPI
     end
 
     before do
-      halt 403 unless authenticated?(params[:api_key])
+      halt 200, {'Content-Type' => 'application/json'}, { api_version: FeverAPI::API_VERSION, auth: 0 }.to_json unless authenticated?(params[:api_key])
     end
 
     def authenticated?(api_key)

--- a/spec/fever_api_spec.rb
+++ b/spec/fever_api_spec.rb
@@ -17,6 +17,9 @@ describe FeverAPI do
   let(:standard_answer) do
     { api_version: 3, auth: 1, last_refreshed_on_time: 123456789 }
   end
+  let(:cannot_auth) do
+    { api_version: 3, auth: 0 }
+  end
   let(:headers) { { api_key: api_key } }
 
   before do
@@ -34,16 +37,19 @@ describe FeverAPI do
     it "authenticates request with correct api_key" do
       get "/", headers
       expect(last_response).to be_ok
+      expect(last_response_as_object).to include(standard_answer)
     end
 
     it "does not authenticate request with incorrect api_key" do
       get "/", api_key: "foo"
-      expect(last_response).not_to be_ok
+      expect(last_response).to be_ok
+      expect(last_response_as_object).to include(cannot_auth)
     end
 
     it "does not authenticate request when api_key is not provided" do
       get "/"
-      expect(last_response).not_to be_ok
+      expect(last_response).to be_ok
+      expect(last_response_as_object).to include(cannot_auth)
     end
   end
 


### PR DESCRIPTION
I am the developer of Unread, an RSS reader for iOS:

https://www.goldenhillsoftware.com/unread/

I recently implemented Fever URL validation. Unread performs this validation before asking for the customer's credentials. This validation attempts to confirm that the Fever URL is correct by issuing a request to the Fever API without an API key and verifying that the API returns the following JSON:

{ "api_version": 3, "auth": 0 }

This works with Fever, but it is not working with Stringer because Stringer responds with a 403 and no response body when the request does not contain the correct API key. This pull request makes Stringer consistent with Fever in this regard.